### PR TITLE
fix: decouple UI config test data from historical migration

### DIFF
--- a/api/src/core/adapters/dbApi/kysely/migrations/1781768391060_add-config-ui-table.ts
+++ b/api/src/core/adapters/dbApi/kysely/migrations/1781768391060_add-config-ui-table.ts
@@ -124,7 +124,7 @@ const migrationUiConfigSchema = strictObject({
     footer: strictObject({ domains: z.array(z.string()) })
 });
 
-export const STANDARD_UI_CONFIG = migrationUiConfigSchema.parse({
+const STANDARD_UI_CONFIG = migrationUiConfigSchema.parse({
     header: {
         link: {
             enabled: true,

--- a/api/src/core/uiConfigDeploymentExamples.test.ts
+++ b/api/src/core/uiConfigDeploymentExamples.test.ts
@@ -2,10 +2,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-    readInitialUiConfig,
-    STANDARD_UI_CONFIG
-} from "./adapters/dbApi/kysely/migrations/1781768391060_add-config-ui-table";
+import { readInitialUiConfig } from "./adapters/dbApi/kysely/migrations/1781768391060_add-config-ui-table";
 import { uiConfigSchema } from "./uiConfigSchema";
 
 describe("UI configuration deployment examples", () => {
@@ -44,7 +41,7 @@ describe("legacy UI configuration migration", () => {
     it("finds the dist mount when Kysely executes the migration from source", async () => {
         const { sourceMigrationDirectory, distConfigPath } = await createSimulatedImage();
         const legacyConfig = {
-            ...STANDARD_UI_CONFIG,
+            ...(await readInitialUiConfig(sourceMigrationDirectory)),
             footer: { domains: ["legacy.example.gouv.fr"] }
         };
         await writeConfig(distConfigPath, legacyConfig);
@@ -55,7 +52,7 @@ describe("legacy UI configuration migration", () => {
     it("finds the source mount when the compiled migration is executed", async () => {
         const { distMigrationDirectory, sourceConfigPath } = await createSimulatedImage();
         const legacyConfig = {
-            ...STANDARD_UI_CONFIG,
+            ...(await readInitialUiConfig(distMigrationDirectory)),
             footer: { domains: ["source.example.gouv.fr"] }
         };
         await writeConfig(sourceConfigPath, legacyConfig);
@@ -66,7 +63,10 @@ describe("legacy UI configuration migration", () => {
     it("uses the embedded standard only when neither legacy path exists", async () => {
         const { sourceMigrationDirectory } = await createSimulatedImage();
 
-        await expect(readInitialUiConfig(sourceMigrationDirectory)).resolves.toEqual(STANDARD_UI_CONFIG);
+        await expect(readInitialUiConfig(sourceMigrationDirectory)).resolves.toMatchObject({
+            header: { link: { text: "Code Gouv" } },
+            footer: { domains: ["info.gouv.fr", "service-public.fr", "legifrance.gouv.fr", "data.gouv.fr"] }
+        });
     });
 
     it.each([

--- a/api/src/rpc/uiConfig.e2e.test.ts
+++ b/api/src/rpc/uiConfig.e2e.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Database } from "../core/adapters/dbApi/kysely/kysely.database";
 import { createPgDialect } from "../core/adapters/dbApi/kysely/kysely.dialect";
 import { DbApiV2 } from "../core/ports/DbApiV2";
-import { STANDARD_UI_CONFIG } from "../core/adapters/dbApi/kysely/migrations/1781768391060_add-config-ui-table";
+import { standardUiConfig } from "../tools/fixtures/standardUiConfig";
 import { resetDB, testPgUrl } from "../tools/test.helpers";
 import { ApiCaller, createTestCaller, defaultUser } from "./createTestCaller";
 
@@ -38,8 +38,8 @@ describe("UI configuration RPC", () => {
         }));
     });
 
-    it("serves the standard configuration inserted by the migration", async () => {
-        await expect(dbApi.uiConfig.get()).resolves.toEqual(STANDARD_UI_CONFIG);
+    it("serves the current standard configuration inserted by the test setup", async () => {
+        await expect(dbApi.uiConfig.get()).resolves.toEqual(standardUiConfig);
     });
 
     it("lets an admin persist a valid configuration", async () => {
@@ -100,7 +100,7 @@ describe("UI configuration RPC", () => {
             .updateTable("config_ui")
             .set({
                 config: JSON.stringify({
-                    ...STANDARD_UI_CONFIG,
+                    ...standardUiConfig,
                     unexpectedProperty: true
                 })
             })

--- a/api/src/rpc/uiConfig.e2e.test.ts
+++ b/api/src/rpc/uiConfig.e2e.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Database } from "../core/adapters/dbApi/kysely/kysely.database";
 import { createPgDialect } from "../core/adapters/dbApi/kysely/kysely.dialect";
 import { DbApiV2 } from "../core/ports/DbApiV2";
-import { standardUiConfig } from "../tools/fixtures/standardUiConfig";
+import { testUiConfig } from "../tools/fixtures/testUiConfig";
 import { resetDB, testPgUrl } from "../tools/test.helpers";
 import { ApiCaller, createTestCaller, defaultUser } from "./createTestCaller";
 
@@ -38,8 +38,8 @@ describe("UI configuration RPC", () => {
         }));
     });
 
-    it("serves the current standard configuration inserted by the test setup", async () => {
-        await expect(dbApi.uiConfig.get()).resolves.toEqual(standardUiConfig);
+    it("serves the configuration inserted by the test setup", async () => {
+        await expect(dbApi.uiConfig.get()).resolves.toEqual(testUiConfig);
     });
 
     it("lets an admin persist a valid configuration", async () => {
@@ -100,7 +100,7 @@ describe("UI configuration RPC", () => {
             .updateTable("config_ui")
             .set({
                 config: JSON.stringify({
-                    ...standardUiConfig,
+                    ...testUiConfig,
                     unexpectedProperty: true
                 })
             })

--- a/api/src/tools/fixtures/standardUiConfig.ts
+++ b/api/src/tools/fixtures/standardUiConfig.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import { type UiConfig, uiConfigSchema } from "../../core/uiConfigSchema";
+
+// Current application test data: evolve with uiConfigSchema, independently of historical migrations.
+export const standardUiConfig = uiConfigSchema.parse({
+    header: {
+        link: {
+            enabled: true,
+            icon: "bank",
+            linkProps: { href: "https://code.gouv.fr" },
+            text: "Code Gouv"
+        },
+        menu: {
+            welcome: { enabled: true },
+            catalog: { enabled: true },
+            addSoftware: { enabled: true },
+            about: { enabled: true },
+            contribute: {
+                enabled: true,
+                href: "mailto:floss@numerique.gouv.fr?subject=Demande d'accompagnement"
+            },
+            login: { enabled: true }
+        }
+    },
+    home: {
+        softwareSelection: { enabled: true },
+        theSillInAFewWordsParagraphLinks: [
+            "https://fr.wikipedia.org/wiki/Logiciel_libre",
+            "https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000033203039",
+            "https://code.gouv.fr/sill/readme",
+            "https://code.gouv.fr/fr/doc/licences-libres-dinum"
+        ],
+        searchBar: { enabled: false },
+        statistics: {
+            categories: ["softwareCount", "registeredUserCount", "agentReferentCount", "organizationCount"]
+        },
+        usecases: {
+            declareReferent: { enabled: true, labelLinks: [], buttonEnabled: true, buttonLink: "" },
+            editSoftware: { enabled: true, labelLinks: [], buttonEnabled: true, buttonLink: "" },
+            addSoftwareOrService: { enabled: true, labelLinks: [], buttonEnabled: true, buttonLink: "" }
+        },
+        quickAccess: { enabled: false }
+    },
+    softwareDetails: {
+        authorCard: false,
+        defaultLogo: true,
+        details: {
+            enabled: true,
+            fields: {
+                registerDate: true,
+                minimalVersionRequired: true,
+                softwareCurrentVersion: true,
+                softwareCurrentVersionDate: true,
+                license: true
+            }
+        },
+        customAttributes: { enabled: true },
+        metadata: {
+            enabled: true,
+            fields: {
+                keywords: true,
+                programmingLanguages: true,
+                applicationCategories: true,
+                runtimePlatforms: true
+            }
+        },
+        repoMetadata: { enabled: false },
+        links: { enabled: true },
+        userActions: { enabled: true }
+    },
+    catalog: {
+        defaultLogo: true,
+        search: {
+            options: {
+                organisation: true,
+                applicationCategories: true,
+                runtimePlatforms: true,
+                customAttributes: true,
+                programmingLanguages: false
+            }
+        },
+        sortOptions: {
+            referent_count: true,
+            user_count: true,
+            added_time: true,
+            update_time: true,
+            latest_version_publication_date: true,
+            user_count_ASC: true,
+            referent_count_ASC: true
+        },
+        cardOptions: { referentCount: true, userCase: true }
+    },
+    footer: { domains: ["info.gouv.fr", "service-public.fr", "legifrance.gouv.fr", "data.gouv.fr"] }
+} satisfies UiConfig);

--- a/api/src/tools/fixtures/testUiConfig.ts
+++ b/api/src/tools/fixtures/testUiConfig.ts
@@ -5,7 +5,7 @@
 import { type UiConfig, uiConfigSchema } from "../../core/uiConfigSchema";
 
 // Current application test data: evolve with uiConfigSchema, independently of historical migrations.
-export const standardUiConfig = uiConfigSchema.parse({
+export const testUiConfig = uiConfigSchema.parse({
     header: {
         link: {
             enabled: true,

--- a/api/src/tools/test.helpers.ts
+++ b/api/src/tools/test.helpers.ts
@@ -7,7 +7,7 @@ import { DeclarationFormData, InstanceFormData, SoftwareFormData, Source } from 
 import { Kysely } from "kysely";
 import { Database } from "../core/adapters/dbApi/kysely/kysely.database";
 import { ExternalDataOriginKind, SoftwareExternalDataOption } from "../lib/ApiTypes";
-import { STANDARD_UI_CONFIG } from "../core/adapters/dbApi/kysely/migrations/1781768391060_add-config-ui-table";
+import { standardUiConfig } from "./fixtures/standardUiConfig";
 
 export const testPgUrl = "postgresql://catalogi:pg_password@localhost:5432/db";
 
@@ -176,9 +176,9 @@ export const resetDB = async (db: Kysely<Database>) => {
     // intentionally never recreates a missing row.
     await db
         .insertInto("config_ui")
-        .values({ id: true, config: JSON.stringify(STANDARD_UI_CONFIG) })
+        .values({ id: true, config: JSON.stringify(standardUiConfig) })
         .onConflict(oc =>
-            oc.column("id").doUpdateSet({ config: JSON.stringify(STANDARD_UI_CONFIG), updatedAt: new Date() })
+            oc.column("id").doUpdateSet({ config: JSON.stringify(standardUiConfig), updatedAt: new Date() })
         )
         .execute();
 

--- a/api/src/tools/test.helpers.ts
+++ b/api/src/tools/test.helpers.ts
@@ -7,7 +7,7 @@ import { DeclarationFormData, InstanceFormData, SoftwareFormData, Source } from 
 import { Kysely } from "kysely";
 import { Database } from "../core/adapters/dbApi/kysely/kysely.database";
 import { ExternalDataOriginKind, SoftwareExternalDataOption } from "../lib/ApiTypes";
-import { standardUiConfig } from "./fixtures/standardUiConfig";
+import { testUiConfig } from "./fixtures/testUiConfig";
 
 export const testPgUrl = "postgresql://catalogi:pg_password@localhost:5432/db";
 
@@ -176,10 +176,8 @@ export const resetDB = async (db: Kysely<Database>) => {
     // intentionally never recreates a missing row.
     await db
         .insertInto("config_ui")
-        .values({ id: true, config: JSON.stringify(standardUiConfig) })
-        .onConflict(oc =>
-            oc.column("id").doUpdateSet({ config: JSON.stringify(standardUiConfig), updatedAt: new Date() })
-        )
+        .values({ id: true, config: JSON.stringify(testUiConfig) })
+        .onConflict(oc => oc.column("id").doUpdateSet({ config: JSON.stringify(testUiConfig), updatedAt: new Date() }))
         .execute();
 
     return db


### PR DESCRIPTION
Application tests currently reset `config_ui` using `STANDARD_UI_CONFIG` from the initial migration. When the runtime schema gains a required field, this setup would reinsert the historical format into an already migrated database and fail application bootstrap.

Add an independent `testUiConfig` test fixture, checked by TypeScript and validated with the current `uiConfigSchema`. Use it in `resetDB()` and the UI configuration RPC tests. Keep the historical configuration private to the initial migration and update its import tests to exercise the reader without importing the constant. The historical schema and configuration values are preserved; future schema changes can update the current fixture independently.

Validation:
- 47 tests passed across UI configuration RPC, legacy configuration import, and RPC routes, using a temporary PostgreSQL 16 database with all 36 migrations applied.
- The 7 legacy configuration import tests passed again after removing the historical configuration export.
- API typecheck passed.
- Repository commit hooks passed (formatting, lint, commit message).
