### PR TITLE
feat: show attribute description tooltip in the software form

### DIFF
--- a/web/src/ui/pages/softwareForm/CustomAttributeForm.tsx
+++ b/web/src/ui/pages/softwareForm/CustomAttributeForm.tsx
@@ -1,6 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
+import Tooltip from "@mui/material/Tooltip";
 import type { ApiTypes } from "api";
 import type { NonPostableEvt } from "evt";
 import { useEvt } from "evt/hooks";
@@ -336,9 +337,30 @@ const CustomAttributeFormField = ({
         typeof attributeDefinition.label === "string"
             ? attributeDefinition.label
             : attributeDefinition.label[lang];
+    const description =
+        !attributeDefinition.description ||
+        typeof attributeDefinition.description === "string"
+            ? attributeDefinition.description
+            : attributeDefinition.description[lang];
+    // Mirrors the tooltip already shown for this same attributeDefinition.description
+    // in CustomAttributeDetails.tsx (software details page), so the explanation is
+    // available both when filling the form and when reading the result.
+    const labelWithTooltip = description ? (
+        <>
+            <Tooltip title={description} arrow>
+                <i
+                    className={fr.cx("fr-icon-information-line", "fr-icon--sm", "fr-mr-1v")}
+                    aria-hidden="true"
+                />
+            </Tooltip>
+            {localizedLabel}
+        </>
+    ) : (
+        localizedLabel
+    );
     const label = attributeDefinition.editableByAdminOnly ? (
         <>
-            {localizedLabel}{" "}
+            {labelWithTooltip}{" "}
             <span
                 className={fr.cx(
                     "fr-badge",
@@ -354,7 +376,7 @@ const CustomAttributeFormField = ({
             </span>
         </>
     ) : (
-        localizedLabel
+        labelWithTooltip
     );
     const hintText = attributeDefinition.editableByAdminOnly ? (
         <strong>{t("softwareForm.adminOnlyCustomAttributeHint")}</strong>


### PR DESCRIPTION
Closes #173

## Context

The issue asks for an info tooltip explaining RGAA in the software form, similar to what's already shown elsewhere. Looking at the code, that "elsewhere" already exists generically: `CustomAttributeDetails.tsx` (software details page) builds a tooltip from `attributeDefinition.description` for any custom attribute that has one set. `CustomAttributeForm.tsx` (the form) has no equivalent — the `description` field is read from `AttributeDefinition`, but silently dropped when rendering a form field.

Since attribute definitions (RGAA included) are admin-configured data rather than code, I didn't see anything to add app-side for the RGAA text itself — an admin can already set its `description` via the existing attribute-definition admin UI, pointing at https://accessibilite.numerique.gouv.fr/ as suggested in the issue. What was missing was the form actually rendering that description.

## Change

`CustomAttributeFormField` now resolves `description` the same way `CustomAttributeDetail` already does, and shows the same `fr-icon-information-line` + MUI `Tooltip` next to the label when a description is present. No description set → renders exactly as before.

Happy to adjust the approach if you'd rather handle this differently (e.g. sharing the label+tooltip bit between the two components instead of duplicating the small resolution snippet) — opened this as a working starting point per the CONTRIBUTING note about discussing via issue first, since #173 didn't land on a specific implementation.
