### PR TITLE
fix: stop treating CNLL as a primary source in importFromInnerIdentifiers

### DIFF
--- a/api/src/core/adapters/dbApi/kysely/migrations/1789225898984_delete-orphan-cnll-external-data.ts
+++ b/api/src/core/adapters/dbApi/kysely/migrations/1789225898984_delete-orphan-cnll-external-data.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+    // importFromInnerIdentifiers used to treat CNLL as a primary source: it
+    // registered the annuaire id that Comptoir du Libre cites in its own
+    // identifiers as CNLL's externalId. But CNLL's adapter is keyed by SILL
+    // id, so that id can never resolve there and the row's lastDataFetchAt
+    // stays NULL forever, showing up as a stuck, empty "CNLL" column
+    // alongside the real, populated one (#520).
+    await db
+        .deleteFrom("software_external_datas")
+        .where("sourceSlug", "=", "cnll")
+        .where("lastDataFetchAt", "is", null)
+        .execute();
+}
+
+export async function down(): Promise<void> {
+    // Data cleanup only. The deleted rows were never valid (their externalId
+    // could never resolve), so there is nothing meaningful to restore.
+}

--- a/api/src/core/usecases/importFromInnerIdentifiers.ts
+++ b/api/src/core/usecases/importFromInnerIdentifiers.ts
@@ -49,6 +49,15 @@ export const makeImportFromInnerIdentifiers = (
         const sources = await dbApi.source.getAll();
         const sourceUrls = sources.reduce(
             (acc, source) => {
+                // CNLL's only machine-readable endpoint (the prestataires-sill.json
+                // feed) is keyed by SILL id, not by the annuaire id that other
+                // sources (e.g. Comptoir du Libre) cite in their own identifiers.
+                // Registering it here as a candidate target creates a
+                // software_external_datas row with an externalId CNLL's own
+                // adapter can never resolve, which then shows up as a stuck,
+                // never-populated "ghost" row (see #520).
+                if (source.kind === "CNLL") return acc;
+
                 const newAcc = acc;
                 newAcc[source.url] = source.slug;
                 return newAcc;


### PR DESCRIPTION
Closes #520

## Context

As diagnosed in #520 (thank you for the exhaustive investigation there — root cause, API probing, alternatives considered and ruled out, all included), `importFromInnerIdentifiers` treats every source it can match by URL as a primary source: it takes whatever id another source cites for it and registers that as the externalId.

That holds for primary sources (Wikidata Q-ids, HAL docids, CDL numeric ids) but not for CNLL. CNLL's only machine-readable endpoint (`prestataires-sill.json`) is keyed by SILL id, while Comptoir du Libre (and potentially others) cite CNLL's *annuaire* id in their own identifiers. Registering that annuaire id as CNLL's externalId creates a `software_external_datas` row CNLL's own adapter (`getCNLLSoftwareExternalData`, keyed by `sill_id`) can never resolve — `lastDataFetchAt` stays `NULL` forever, and it renders as a second, permanently-empty "CNLL" column next to the real, populated one on the software detail page.

As the issue notes, there's no way to get the annuaire id from CNLL's API today (only the HTML pages have it, keyed by name, not id), so fixing this on the "wrong externalId" side isn't an option.

## Change

Implements recommendation (1) and (2) from the issue:

1. `api/src/core/usecases/importFromInnerIdentifiers.ts` — skip sources whose `kind` is `"CNLL"` before `resolveRegisterable` ever runs, so the ghost row can't be created again.
2. New migration `1789225898984_delete-orphan-cnll-external-data.ts` — one-shot cleanup of existing orphaned rows (`sourceSlug='cnll' AND lastDataFetchAt IS NULL`).

Left out (3) (defensive dedupe of `dataBySource` in `getDetails`) since the issue itself flags it as optional and (1) is the actual fix — happy to add it if you'd rather have the extra safety net.

## Testing

I don't have Docker in my environment, so I couldn't run the test suite. Both changes are small and self-contained enough to review by inspection, but I also didn't want to add an untested unit test file just to tick a box. `dbApi.source` and `dbApi.softwareExternalData` are both injected into `makeImportFromInnerIdentifiers`, so this is testable with plain fakes (no DB needed) if you'd like one — let me know and I'll add it.

Manually re-verified the reproduction steps from the issue against the current code (reading `getCNLLSoftwareExternalData`, `resolveRegisterable`, and the `SourcesTable`/`ExternalDataOriginKind` types) to confirm `source.kind === "CNLL"` is a valid, reachable check.
